### PR TITLE
ci: don't let a job failure prevent other runners

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -55,6 +55,7 @@ jobs:
       CHUNK_COUNT: 4
 
     strategy:
+      fail-fast: false
       matrix:
         engine: [v8, v8_exp, jsc, sm, sm_exp, chakra, hermes, kiesel, porffor, libjs, engine262, qjs, xs, graaljs, nashorn, rhino, boa, babel, swc, sucrase] # all
 


### PR DESCRIPTION
this should prevent scenarios like the past few days where there's been a bunch of missing data from runner fails

eg https://github.com/CanadaHonk/test262.fyi/actions/runs/6917208430

![image](https://github.com/CanadaHonk/test262.fyi/assets/5464072/a068227f-132f-48cb-9231-0dc232c0d6b2)
