### PR TITLE
meta: fix downloadOldResults script

### DIFF
--- a/scripts/downloadOldResults.mjs
+++ b/scripts/downloadOldResults.mjs
@@ -7,8 +7,8 @@ const { artifacts } = await (await fetch('https://api.github.com/repos/CanadaHon
 if (!existsSync('results')) mkdirSync('results');
 
 for (const engine of engines) {
-  const artifact = artifacts.find(x => x.name === engine);
+  const artifact = artifacts.find(x => x.name.startsWith(engine));
   if (!artifact || existsSync(`results/${engine}`)) continue;
 
-  writeFileSync(`results/${engine}.zip`, Buffer.from(await (await fetch(`https://api.github.com/repos/CanadaHonk/test262.fyi/actions/artifacts/${artifact.id}/zip`, { headers: { Authorization: 'Bearer ' + process.env.GITHUB_TOKEN }})).arrayBuffer()))
+  writeFileSync(`results/${engine}.zip`, Buffer.from(await (await fetch(artifact.archive_download_url, { headers: { Authorization: 'Bearer ' + process.env.GITHUB_TOKEN }})).arrayBuffer()))
 }


### PR DESCRIPTION
The artifact names seem to have changed since the script was last used. Their `name`s are `rhino1`, `rhino2`, etc. instead of just `rhino`. This updates the `downloadOldResults` accordingly.