### PR TITLE
meta: tweak extractResults script

### DIFF
--- a/scripts/extractResults.sh
+++ b/scripts/extractResults.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 for file in results/*.zip
 do


### PR DESCRIPTION
Just FYI: `./scripts/extractResults.sh` failed on macOS by default. Tweaking the shebang like in this patch makes everything work as expected. I also noticed the file had CRLF line endings, which I’m assuming was not intentional.