### PR TITLE
css: let stats table have top+bottom margin too

### DIFF
--- a/site/style.css
+++ b/site/style.css
@@ -112,7 +112,7 @@ th.sub {
 
 table .stats {
   width: calc((100vw - 320px - 4vw) * 0.75 - 12px - 2px);
-  margin: 0 6px;
+  margin: 6px;
 }
 
 thead .stats {


### PR DESCRIPTION
before

<img width="1198" alt="image" src="https://github.com/CanadaHonk/test262.fyi/assets/5464072/0e260908-3e07-4b59-8cfd-9ab9700b7fc5">

after

<img width="1198" alt="image" src="https://github.com/CanadaHonk/test262.fyi/assets/5464072/ba41d816-5db6-4419-9aba-e1155b00da62">

---

this makes the table much easier to read when using the vertical graphs option