### PR TITLE
feat(engines): publish js2 host and standalone lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Independent daily [test262](https://github.com/tc39/test262) (standard test suit
 - [X] Boa <small>[site](https://boajs.dev/)</small> <small>[source](https://github.com/boa-dev/boa)</small>
 - [X] Kiesel <small>[site](https://kiesel.dev)</small> <small>[source](https://codeberg.org/kiesel-js/kiesel)</small>
 - [X] Porffor <small>[site](https://porffor.dev)</small> <small>[source](https://github.com/CanadaHonk/porffor)</small>
+- [X] js2 (standalone WebAssembly GC) <small>[site](https://js2.loopdive.com)</small> <small>[source](https://github.com/loopdive/js2)</small>
 - [x] Nova <small>[site](https://trynova.dev)</small> <small>[source](https://github.com/trynova/nova)</small>
 - [X] NJS <small>[site](https://nginx.org/en/docs/njs/)</small> <small>[source](https://github.com/nginx/njs)</small>
 - [ ] Bali <small>[source](https://github.com/ferus-web/bali)</small>

--- a/controller/index.js
+++ b/controller/index.js
@@ -22,6 +22,7 @@ const engines = [
   'qjs_ng',
   'hermes',
   'porffor',
+  'js2',
   'boa',
   'libjs',
   // 'engine262',

--- a/engines/js2/run.js
+++ b/engines/js2/run.js
@@ -1,0 +1,25 @@
+import { $$ } from '../../util.js';
+
+export default (file, module = false) => {
+  const cli = process.env.JS2_FYI_CLI;
+  const test262Root = process.env.JS2_FYI_TEST262_ROOT;
+  const executable = process.env.JS2_FYI_NODE;
+  if (!cli || !test262Root || !executable) {
+    throw new Error('js2 setup did not publish its CLI paths');
+  }
+
+  const args = [
+    cli,
+    '--target', 'standalone',
+    '--test262-root', test262Root,
+    '--engine-suffix', 'js2'
+  ];
+  if (module) args.push('--module');
+  args.push(file);
+  return $$(executable, args, {
+    TEST262_TZ: 'UTC',
+    // util.$$ enforces the repository-wide ten-second engine timeout. Let the
+    // inner compiler worker stop first so it cannot survive a timed-out CLI.
+    TEST262_FYI_SOURCE_TIMEOUT_MS: '8000'
+  });
+};

--- a/engines/js2/runtime.js
+++ b/engines/js2/runtime.js
@@ -1,0 +1,22 @@
+// Globals compiled into js2's standalone WebAssembly GC Test262 module.
+var print = function (value) {
+  console.log(value);
+};
+
+var $262 = {
+  global: globalThis,
+  IsHTMLDDA: function () {},
+  createRealm: function () {
+    return $262;
+  },
+  evalScript: function (sourceText) {
+    return eval(sourceText);
+  },
+  gc: function () {},
+  detachArrayBuffer: function (buffer) {
+    if (typeof structuredClone !== 'function') {
+      throw new Error('$262.detachArrayBuffer is unsupported by this host');
+    }
+    structuredClone(buffer, { transfer: [buffer] });
+  }
+};

--- a/engines/js2/setup.js
+++ b/engines/js2/setup.js
@@ -1,0 +1,43 @@
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PACKAGE = '@loopdive/js2';
+const PINNED_NODE = '25.9.0';
+
+const run = (command, args, options = {}) => child_process.execFileSync(command, args, {
+  cwd: options.cwd,
+  encoding: 'utf8',
+  stdio: options.capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+  env: { ...process.env, NO_COLOR: '1', ...options.env }
+});
+
+export default async () => {
+  const installRoot = path.resolve('js2-package');
+  const packageRoot = process.env.JS2_FYI_PACKAGE_ROOT
+    ? path.resolve(process.env.JS2_FYI_PACKAGE_ROOT)
+    : path.join(installRoot, 'node_modules', '@loopdive', 'js2');
+
+  if (!process.env.JS2_FYI_PACKAGE_ROOT && !fs.existsSync(path.join(packageRoot, 'dist', 'test262-fyi-cli.js'))) {
+    run('npm', [
+      'install', '--prefix', installRoot, '--no-save', '--omit=dev', '--no-audit', '--no-fund',
+      `${PACKAGE}@latest`, `node@${PINNED_NODE}`
+    ]);
+  }
+
+  const executable = process.env.JS2_FYI_NODE || path.join(installRoot, 'node_modules', 'node', 'bin', 'node');
+  const cli = path.join(packageRoot, 'dist', 'test262-fyi-cli.js');
+  if (!fs.existsSync(executable)) throw new Error(`js2 Node runtime is missing: ${executable}`);
+  if (!fs.existsSync(cli)) throw new Error(`installed ${PACKAGE} does not provide js2-test262: ${cli}`);
+
+  run(executable, [cli, '--check-runtime'], { capture: true });
+  const metadata = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+  const nodeVersion = run(executable, ['--version'], { capture: true }).trim();
+
+  process.env.JS2_FYI_CLI = cli;
+  process.env.JS2_FYI_NODE = executable;
+  process.env.JS2_FYI_TEST262_ROOT = path.resolve('test262');
+  process.env.TEST262_TZ = 'UTC';
+
+  return { version: `${metadata.version} (${nodeVersion})` };
+};


### PR DESCRIPTION
## Summary

- register js2_host and js2_standalone as separate daily test262.fyi engines
- clone and build the latest loopdive/js2 revision during setup
- run both lanes through the canonical js2 Test262 adapter and return direct boolean verdicts
- pin Node 25.9.0 for the Unicode 17 and worker-runtime contract
- cap js2 at two FYI workers by default, with JS2_FYI_WORKERS available for operators

## Why

js2 has materially different capability boundaries in JavaScript-host and host-free standalone mode. Publishing one combined number would hide that distinction. Reusing the js2 adapter also keeps strict reruns, module fixture graphs, negative phases, timeouts, and infrastructure failures aligned with the project CI runner instead of duplicating those semantics in this repository.

Depends on loopdive/js2#3456.

## Validation

- syntax checks for the controller, runner, setup, and lane modules
- end-to-end data-runner smoke against an external Test262 fixture tree
- js2 host: 3/3
- js2 standalone: 3/3
- smoke covers a script test, a static module fixture graph, and a parse-negative test