### PR TITLE
Add escargot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Independent daily [test262](https://github.com/tc39/test262) (standard test suit
 - [x] Nova <small>[site](https://trynova.dev)</small> <small>[source](https://github.com/trynova/nova)</small>
 - [X] NJS <small>[site](https://nginx.org/en/docs/njs/)</small> <small>[source](https://github.com/nginx/njs)</small>
 - [ ] Bali <small>[source](https://github.com/ferus-web/bali)</small>
+- [X] Escargot <small>[source](https://github.com/Samsung/escargot)</small>
 - Request more in GitHub issues!
 
 ### Transpilers

--- a/controller/index.js
+++ b/controller/index.js
@@ -28,7 +28,8 @@ const engines = [
   'xs',
   'njs',
   'kiesel',
-  'nova'
+  'nova',
+  'escargot'
 ];
 
 let queue = process.argv[2]?.split(',').map(x => x.trim()).filter(x => x);

--- a/controller/oom-killer.js
+++ b/controller/oom-killer.js
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 
-const limit  = 1 * 1024 * 1024 * 1024, // 2G
+const limit  = 1 * 1024 * 1024 * 1024, // 1G
       filter = 'test262/test';
 
 let interval, running = false;

--- a/engines/escargot/run.js
+++ b/engines/escargot/run.js
@@ -1,0 +1,8 @@
+import { $$ } from '../../util.js';
+
+export default (file, module = false) => {
+  const args = [ file ];
+  if (module) args.unshift('--module');
+
+  return $$('./escargot', args);
+};

--- a/engines/escargot/runtime.js
+++ b/engines/escargot/runtime.js
@@ -1,0 +1,1 @@
+// Escargot provides the test262 host API natively when built with ESCARGOT_TEST=ON.

--- a/engines/escargot/setup.js
+++ b/engines/escargot/setup.js
@@ -24,7 +24,8 @@ export default async () => {
   $(`git clone https://github.com/Samsung/escargot.git ${buildDir} --depth=1 --recurse-submodules --shallow-submodules`);
   const version = $(`git -C ${buildDir} rev-parse HEAD`).trim().slice(0, 7);
 
-  $(`cmake -S ${buildDir} -B ${buildDir}/build -GNinja -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=shell -DESCARGOT_TEST=ON -DESCARGOT_TEMPORAL=ON -DESCARGOT_SHADOWREALM=ON`, env);
+  // escargot and its submodules still declare cmake_minimum_required 2.8.12, which cmake 4 rejects outright
+  $(`cmake -S ${buildDir} -B ${buildDir}/build -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=shell -DESCARGOT_TEST=ON -DESCARGOT_TEMPORAL=ON -DESCARGOT_SHADOWREALM=ON`, env);
   $(`cmake --build ${buildDir}/build`, env);
   $(`cp -rf ${buildDir}/build/escargot ./escargot`);
   $(`rm -rf ${buildDir}`);

--- a/engines/escargot/setup.js
+++ b/engines/escargot/setup.js
@@ -1,0 +1,33 @@
+import { $, $$ } from '../../util.js';
+
+const buildDir = 'escargot-src';
+
+// escargot needs icu, which is keg-only in homebrew so pkg-config can't find it by default
+const icuEnv = () => {
+  if (process.platform !== 'darwin') return {};
+
+  const { stdout, error } = $$('brew', ['--prefix', 'icu4c']);
+  if (error) {
+    console.error('escargot: could not locate icu4c via homebrew, build will likely fail (install with `brew install icu4c`, or set PKG_CONFIG_PATH yourself)');
+    return {};
+  }
+
+  return {
+    PKG_CONFIG_PATH: [`${stdout.trim()}/lib/pkgconfig`, process.env.PKG_CONFIG_PATH].filter(Boolean).join(':')
+  };
+};
+
+export default async () => {
+  const env = icuEnv();
+
+  $(`rm -rf ${buildDir}`);
+  $(`git clone https://github.com/Samsung/escargot.git ${buildDir} --depth=1 --recurse-submodules --shallow-submodules`);
+  const version = $(`git -C ${buildDir} rev-parse HEAD`).trim().slice(0, 7);
+
+  $(`cmake -S ${buildDir} -B ${buildDir}/build -GNinja -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=shell -DESCARGOT_TEST=ON -DESCARGOT_TEMPORAL=ON -DESCARGOT_SHADOWREALM=ON`, env);
+  $(`cmake --build ${buildDir}/build`, env);
+  $(`cp -rf ${buildDir}/build/escargot ./escargot`);
+  $(`rm -rf ${buildDir}`);
+
+  return { version };
+};


### PR DESCRIPTION
### Two build note:
escargot links against icu, which is keg-only in homebrew and so invisible to pkg-config, hence the `PKG_CONFIG_PATH` handling on darwin. And escargot and its submodules still declare `cmake_minimum_required(VERSION 2.8.12)`, which cmake 4 rejects outright since it dropped compatibility with policy versions below 3.5 — `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` works around this until escargot bumps its minimum.
  
Built and ran a full test262 pass on both Linux (x64) and macOS (arm64).